### PR TITLE
Fix LinkageError when starting angry-ip-scanner

### DIFF
--- a/org.angryip.ipscan.yaml
+++ b/org.angryip.ipscan.yaml
@@ -1,9 +1,9 @@
 app-id: org.angryip.ipscan
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk11
+  - org.freedesktop.Sdk.Extension.openjdk21
 command: ipscan
 finish-args:
   - --socket=wayland
@@ -18,7 +18,7 @@ modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk11/install.sh
+      - /usr/lib/sdk/openjdk21/install.sh
 
   - name: ipscan
     buildsystem: simple


### PR DESCRIPTION
Updated runtime version to 25.08 and openjdk version to 21 to prevent this error when trying to start angry-ip-scanner:
```
user@host ~> flatpak run org.angryip.ipscan
Error: LinkageError occurred while loading main class net.azib.ipscan.Main
	java.lang.UnsupportedClassVersionError: net/azib/ipscan/Main has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
user@host ~ [1]>
```

AngryIP Scanner Version: 3.9.2
Tested on Linux Fedora Workstation 42.